### PR TITLE
Res to RES

### DIFF
--- a/nusystematics/systproviders/GENIEReWeightParamConfig.cc
+++ b/nusystematics/systproviders/GENIEReWeightParamConfig.cc
@@ -286,7 +286,7 @@ SystMetaData ConfigureRESParameterHeaders(fhicl::ParameterSet const &cfg,
   }
 
   SystMetaData CCRESmd = ConfigureSetOfDependentShapeableParameters(
-      cfg, firstParamId, tool_options, "CCResVariationResponse",
+      cfg, firstParamId, tool_options, "CCRESVariationResponse",
       {{kXSecTwkDial_MaCCRES, kXSecTwkDial_MaCCRESshape},
        {kXSecTwkDial_MvCCRES, kXSecTwkDial_MvCCRESshape}},
       CCRESIsShapeOnly);
@@ -315,7 +315,7 @@ SystMetaData ConfigureRESParameterHeaders(fhicl::ParameterSet const &cfg,
   }
 
   SystMetaData NCRESmd = ConfigureSetOfDependentShapeableParameters(
-      cfg, firstParamId, tool_options, "NCResVariationResponse",
+      cfg, firstParamId, tool_options, "NCRESVariationResponse",
       {{kXSecTwkDial_MaNCRES, kXSecTwkDial_MaNCRESshape},
        {kXSecTwkDial_MvNCRES, kXSecTwkDial_MvNCRESshape}},
       NCRESIsShapeOnly);


### PR DESCRIPTION
`Res` should be `RES` (upper-case) to match with what we do here:
https://github.com/LArSoft/nusystematics/blob/e4870ad4117af2d750c962224dc9d5b91a715655/nusystematics/systproviders/GENIEReWeightEngineConfig.cc#L303
https://github.com/LArSoft/nusystematics/blob/e4870ad4117af2d750c962224dc9d5b91a715655/nusystematics/systproviders/GENIEReWeightEngineConfig.cc#L328