### PR TITLE
Update GENIE Reweight parameters

### DIFF
--- a/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
+++ b/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
@@ -10,6 +10,7 @@
 #include "RwCalculators/GReWeightNuXSecCCQE.h"
 #include "RwCalculators/GReWeightNuXSecCCQEaxial.h"
 #include "RwCalculators/GReWeightNuXSecCCQEvec.h"
+#include "RwCalculators/GReWeightXSecMEC.h"
 #include "RwCalculators/GReWeightNuXSecCCRES.h"
 #include "RwCalculators/GReWeightNuXSecCOH.h"
 #include "RwCalculators/GReWeightNuXSecDIS.h"
@@ -261,7 +262,31 @@ ConfigureQEWeightEngine(SystMetaData const &QEmd,
       []() { return new GReWeightNuXSecCCQEvec; }, UseFullHERG, param_map);
 
   return param_map;
-} // namespace nusyst
+}
+
+std::vector<GENIEResponseParameter>
+ConfigureMECWeightEngine(SystMetaData const &MECmd,
+                        fhicl::ParameterSet const &tool_options) {
+
+  std::vector<GENIEResponseParameter> param_map;
+
+  bool UseFullHERG = tool_options.get<bool>("UseFullHERG", false);
+
+  AddIndependentParameters(
+      MECmd, {
+        kXSecTwkDial_NormCCMEC,
+        kXSecTwkDial_NormNCMEC,
+        kXSecTwkDial_NormEMMEC,
+        kXSecTwkDial_DecayAngMEC,
+        kXSecTwkDial_FracPN_CCMEC,
+        kXSecTwkDial_FracDelta_CCMEC,
+        kXSecTwkDial_XSecShape_CCMEC
+      },
+      "xsec_mec", []() { return new GReWeightXSecMEC; }, UseFullHERG, param_map);
+
+  return param_map;
+
+}
 
 std::vector<GENIEResponseParameter>
 ConfigureNCELWeightEngine(SystMetaData const &NCELmd,

--- a/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
+++ b/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
@@ -17,6 +17,7 @@
 #include "RwCalculators/GReWeightNuXSecNCEL.h"
 #include "RwCalculators/GReWeightNuXSecNCRES.h"
 #include "RwCalculators/GReWeightResonanceDecay.h"
+#include "RwCalculators/GReWeightDeltaradAngle.h"
 
 #include <functional>
 
@@ -389,6 +390,13 @@ ConfigureRESWeightEngine(SystMetaData const &RESmd,
                            "xsec_ResDecay",
                            []() { return new GReWeightResonanceDecay(); },
                            UseFullHERG, param_map);
+
+  AddIndependentParameters(RESmd,
+                           {{kRDcyTwkDial_Theta_Delta2NRad}},
+                           "xsec_DeltaRad",
+                           []() { return new GReWeightDeltaradAngle(); },
+                           UseFullHERG, param_map);
+
 
   return param_map;
 }

--- a/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
+++ b/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
@@ -261,6 +261,14 @@ ConfigureQEWeightEngine(SystMetaData const &QEmd,
       QEmd, {kXSecTwkDial_VecFFCCQEshape}, "xsec_ccqe_vecFF",
       []() { return new GReWeightNuXSecCCQEvec; }, UseFullHERG, param_map);
 
+  AddIndependentParameters(
+      QEmd, {kXSecTwkDial_RPA_CCQE}, "xsec_ccqe_rpa",
+      []() { return new GReWeightNuXSecCCQE; }, UseFullHERG, param_map);
+
+  AddIndependentParameters(
+      QEmd, {kXSecTwkDial_CoulombCCQE}, "xsec_ccqe_coulomb",
+      []() { return new GReWeightNuXSecCCQE; }, UseFullHERG, param_map);
+
   return param_map;
 }
 

--- a/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
+++ b/nusystematics/systproviders/GENIEReWeightEngineConfig.cc
@@ -411,7 +411,7 @@ ConfigureCOHWeightEngine(SystMetaData const &COHmd,
 
   AddResponseAndDependentDials(
       COHmd, "COHVariationResponse",
-      {kXSecTwkDial_MaCOHpi, kXSecTwkDial_R0COHpi}, "xsec_COH",
+      {kXSecTwkDial_MaCOHpi, kXSecTwkDial_R0COHpi, kXSecTwkDial_NormCCCOHpi, kXSecTwkDial_NormNCCOHpi}, "xsec_COH",
       []() { return new GReWeightNuXSecCOH; }, UseFullHERG, param_map);
 
   return param_map;

--- a/nusystematics/systproviders/GENIEReWeightEngineConfig.hh
+++ b/nusystematics/systproviders/GENIEReWeightEngineConfig.hh
@@ -20,6 +20,10 @@ ConfigureQEWeightEngine(systtools::SystMetaData const &,
                         fhicl::ParameterSet const &tool_options);
 
 std::vector<GENIEResponseParameter>
+ConfigureMECWeightEngine(systtools::SystMetaData const &,
+                        fhicl::ParameterSet const &tool_options);
+
+std::vector<GENIEResponseParameter>
 ConfigureNCELWeightEngine(systtools::SystMetaData const &,
                           fhicl::ParameterSet const &tool_options);
 

--- a/nusystematics/systproviders/GENIEReWeightParamConfig.cc
+++ b/nusystematics/systproviders/GENIEReWeightParamConfig.cc
@@ -249,7 +249,24 @@ SystMetaData ConfigureQEParameterHeaders(fhicl::ParameterSet const &cfg,
 
 
   return QEmd;
-} // namespace nusyst
+}
+
+SystMetaData ConfigureMECParameterHeaders(fhicl::ParameterSet const &cfg,
+                                          paramId_t firstParamId,
+                                          fhicl::ParameterSet &tool_options) {
+
+  return ConfigureSetOfIndependentParameters(
+      cfg, firstParamId,
+      {kXSecTwkDial_NormCCMEC,
+       kXSecTwkDial_NormNCMEC,
+       kXSecTwkDial_NormEMMEC,
+       kXSecTwkDial_DecayAngMEC,
+       kXSecTwkDial_FracPN_CCMEC,
+       kXSecTwkDial_FracDelta_CCMEC,
+       kXSecTwkDial_XSecShape_CCMEC}
+  );
+
+}
 
 SystMetaData ConfigureNCELParameterHeaders(fhicl::ParameterSet const &cfg,
                                            paramId_t firstParamId,

--- a/nusystematics/systproviders/GENIEReWeightParamConfig.cc
+++ b/nusystematics/systproviders/GENIEReWeightParamConfig.cc
@@ -376,7 +376,7 @@ SystMetaData ConfigureCOHParameterHeaders(fhicl::ParameterSet const &cfg,
                                           fhicl::ParameterSet &tool_options) {
   return ConfigureSetOfDependentParameters(
       cfg, firstParamId, tool_options, "COHVariationResponse",
-      {kXSecTwkDial_MaCOHpi, kXSecTwkDial_R0COHpi});
+      {kXSecTwkDial_MaCOHpi, kXSecTwkDial_R0COHpi, kXSecTwkDial_NormCCCOHpi, kXSecTwkDial_NormNCCOHpi});
 }
 
 SystMetaData ConfigureDISParameterHeaders(fhicl::ParameterSet const &cfg,

--- a/nusystematics/systproviders/GENIEReWeightParamConfig.cc
+++ b/nusystematics/systproviders/GENIEReWeightParamConfig.cc
@@ -364,7 +364,8 @@ SystMetaData ConfigureRESParameterHeaders(fhicl::ParameterSet const &cfg,
        kXSecTwkDial_RvbarnNC2pi,
 
        kRDcyTwkDial_BR1gamma, kRDcyTwkDial_BR1eta,
-       kRDcyTwkDial_Theta_Delta2Npi});
+       kRDcyTwkDial_Theta_Delta2Npi,
+       kRDcyTwkDial_Theta_Delta2NRad});
   ExtendSystMetaData(RESmd, std::move(RESOther));
 
   return RESmd;

--- a/nusystematics/systproviders/GENIEReWeightParamConfig.cc
+++ b/nusystematics/systproviders/GENIEReWeightParamConfig.cc
@@ -240,7 +240,20 @@ SystMetaData ConfigureQEParameterHeaders(fhicl::ParameterSet const &cfg,
   SystMetaData VecFFCCQEmd = ConfigureSetOfIndependentParameters(
       cfg, firstParamId,
       {kXSecTwkDial_VecFFCCQEshape});
+  firstParamId += VecFFCCQEmd.size();
   ExtendSystMetaData(QEmd, std::move(VecFFCCQEmd));
+
+  SystMetaData RPA_CCQEmd = ConfigureSetOfIndependentParameters(
+      cfg, firstParamId,
+      {kXSecTwkDial_RPA_CCQE});
+  firstParamId += RPA_CCQEmd.size();
+  ExtendSystMetaData(QEmd, std::move(RPA_CCQEmd));
+
+  SystMetaData CoulombCCQEmd = ConfigureSetOfIndependentParameters(
+      cfg, firstParamId,
+      {kXSecTwkDial_CoulombCCQE});
+  firstParamId += CoulombCCQEmd.size();
+  ExtendSystMetaData(QEmd, std::move(CoulombCCQEmd));
 
   bool AxFFCCQEDipoleToZExp =
       cfg.get<bool>("AxFFCCQEDipoleToZExp", false) || IsZExpReWeight;

--- a/nusystematics/systproviders/GENIEReWeightParamConfig.hh
+++ b/nusystematics/systproviders/GENIEReWeightParamConfig.hh
@@ -14,6 +14,10 @@ ConfigureQEParameterHeaders(fhicl::ParameterSet const &, systtools::paramId_t,
                             fhicl::ParameterSet &tool_options);
 
 systtools::SystMetaData
+ConfigureMECParameterHeaders(fhicl::ParameterSet const &, systtools::paramId_t,
+                            fhicl::ParameterSet &tool_options);
+
+systtools::SystMetaData
 ConfigureNCELParameterHeaders(fhicl::ParameterSet const &, systtools::paramId_t,
                               fhicl::ParameterSet &tool_options);
 

--- a/nusystematics/systproviders/GENIEReWeight_tool.cc
+++ b/nusystematics/systproviders/GENIEReWeight_tool.cc
@@ -58,6 +58,10 @@ SystMetaData GENIEReWeight::BuildSystMetaData(ParameterSet const &params,
       ConfigureQEParameterHeaders(params, firstParamId, tool_options);
   firstParamId += QEmd.size();
 
+  SystMetaData MECmd =
+      ConfigureMECParameterHeaders(params, firstParamId, tool_options);
+  firstParamId += MECmd.size();
+
   SystMetaData NCELmd =
       ConfigureNCELParameterHeaders(params, firstParamId, tool_options);
   firstParamId += NCELmd.size();
@@ -83,6 +87,7 @@ SystMetaData GENIEReWeight::BuildSystMetaData(ParameterSet const &params,
 
   // Don't extend inline to make firstParamId incrementing more clear.
   ExtendSystMetaData(QEmd, DISmd);
+  ExtendSystMetaData(QEmd, MECmd);
   ExtendSystMetaData(QEmd, NCELmd);
   ExtendSystMetaData(QEmd, RESmd);
   ExtendSystMetaData(QEmd, COHmd);

--- a/nusystematics/systproviders/GENIEReWeight_tool.cc
+++ b/nusystematics/systproviders/GENIEReWeight_tool.cc
@@ -131,6 +131,9 @@ bool GENIEReWeight::SetupResponseCalculator(
       ConfigureQEWeightEngine(GetSystMetaData(), tool_options));
 
   extend_ResponseToGENIEParameters(
+      ConfigureMECWeightEngine(GetSystMetaData(), tool_options));
+
+  extend_ResponseToGENIEParameters(
       ConfigureNCELWeightEngine(GetSystMetaData(), tool_options));
 
   extend_ResponseToGENIEParameters(


### PR DESCRIPTION
We noticed some of the new GENIE Reweight dials were not activated in nusystematics. Also, MEC Reweight engines are now added.
GSyst and its corresponding Reweight RwCalculators are list below:
```
# CCQE
kXSecTwkDial_RPA_CCQE GReWeightNuXSecCCQE
kXSecTwkDial_CoulombCCQE GReWeightNuXSecCCQE
# MEC (new interaction category added in nusystematics)
kXSecTwkDial_NormCCMEC GReWeightXSecMEC
kXSecTwkDial_NormNCMEC GReWeightXSecMEC
kXSecTwkDial_NormEMMEC GReWeightXSecMEC
kXSecTwkDial_DecayAngMEC GReWeightXSecMEC
kXSecTwkDial_FracPN_CCMEC GReWeightXSecMEC
kXSecTwkDial_FracDelta_CCMEC GReWeightXSecMEC
kXSecTwkDial_XSecShape_CCMEC GReWeightXSecMEC
# RES
kRDcyTwkDial_Theta_Delta2NRad GReWeightDeltaradAngle
# COH
kXSecTwkDial_NormCCCOHpi GReWeightNuXSecCOH
kXSecTwkDial_NormNCCOHpi GReWeightNuXSecCOH
```